### PR TITLE
Parent index sort

### DIFF
--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -1,6 +1,6 @@
 class DojosController < ApplicationController
   def index
-    @dojos = Dojo.all
+    @dojos = Dojo.all.order(:created_at)
   end
 
   def show

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -1,3 +1,7 @@
 class Dojo < ApplicationRecord
   has_many :instructors
+
+  def self.recently_created
+    order(:created_at)
+  end
 end

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -2,3 +2,4 @@
 <h3><%= @company.id %></h3>
 <h3><%= @company.accepting_orders %></h3>
 <h3><%= @company.years_active %></h3>
+<h3><%= @company.seeds.count %></h3>

--- a/app/views/dojos/index.html.erb
+++ b/app/views/dojos/index.html.erb
@@ -1,3 +1,4 @@
 <% @dojos.each do |dojo| %>
   <p><%= dojo.name %></p>
+  <p><%= dojo.created_at %></p>
 <% end %>

--- a/app/views/dojos/show.html.erb
+++ b/app/views/dojos/show.html.erb
@@ -2,3 +2,4 @@
 <h3><%= @dojo.id %></h3>
 <h3><%= @dojo.open %></h3>
 <h3><%= @dojo.rating %></h3>
+<h3><%= @dojo.instructors.count %></h3>

--- a/spec/features/companies/show_spec.rb
+++ b/spec/features/companies/show_spec.rb
@@ -4,16 +4,25 @@ RSpec.describe 'company show page' do
   describe 'when I visit /companies/:id' do
     it 'displays the company with id and its attributes' do
       company = Company.create!(name: "Johnny's Seeds", accepting_orders: true, years_active: 10)
-      company_2 = Company.create!(name: "Turing Seeds", accepting_orders: false, years_active: 6)
+      company_2 = Company.create!(name: "Turing Seeds", accepting_orders: false, years_active: 12)
+
       visit "/companies/#{company.id}"
-      
+
       expect(page).to have_content(company.name)
       expect(page).to have_content(company.accepting_orders)
       expect(page).to have_content(company.years_active)
 
       expect(page).to_not have_content(company_2.name)
-      expect(page).to_not have_content(company_2.accepting_orders)
-      expect(page).to_not have_content(company_2.years_active)
+    end
+
+    it 'displays the quantity of instructors in the Dojo' do
+      company = Company.create!(name: "Johnny's Seeds", accepting_orders: true, years_active: 10)
+      seed = company.seeds.create!(name: "Jessica", available: true, quantity: 3)
+      seed_2 = company.seeds.create!(name: "Jimmy", available: false, quantity: 55)
+
+      visit "/companies/#{company.id}"
+
+      expect(page).to have_content(company.seeds.count)
     end
   end
 end

--- a/spec/features/dojos/index_spec.rb
+++ b/spec/features/dojos/index_spec.rb
@@ -8,6 +8,17 @@ RSpec.describe 'dojo index page' do
 
       expect(page).to have_content(dojo.name)
     end
+
+    it 'returns the name of each dojo in order of most recently created' do
+      dojo = Dojo.create!(name: "Blue Fist", open: true, rating: 2, created_at: Time.now + 1)
+      dojo_2 = Dojo.create!(name: "Fist of Truth", open: false, rating: 4, created_at: Time.now + 2)
+      dojo_3 = Dojo.create!(name: "Fists of Fury", open: true, rating: 1, created_at: Time.now + 3)
+
+      visit "/dojos"
+
+      expect(dojo.name).to appear_before(dojo_2.name)
+      expect(dojo_2.name).to appear_before(dojo_3.name)
+    end
   end
 end
 

--- a/spec/features/dojos/show_spec.rb
+++ b/spec/features/dojos/show_spec.rb
@@ -12,8 +12,16 @@ RSpec.describe 'dojo show page' do
       expect(page).to have_content(dojo.rating)
 
       expect(page).to_not have_content(dojo_2.name)
-      expect(page).to_not have_content(dojo_2.open)
-      expect(page).to_not have_content(dojo_2.rating)
+    end
+
+    it 'displays the quantity of instructors in the Dojo' do
+      dojo = Dojo.create!(name: "Blue Fist", open: true, rating: 2)
+      instructor = dojo.instructors.create!(name: "Jessica", payroll: true, experience: 3)
+      instructor_2 = dojo.instructors.create!(name: "Jimmy", payroll: false, experience: 55)
+
+      visit "/dojos/#{dojo.id}"
+
+      expect(page).to have_content(dojo.instructors.count)
     end
   end
 end

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -2,4 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Dojo do
   it { should have_many :instructors }
+
+  it 'order the dojos by most recently created' do
+    dojo = Dojo.create!(name: "Blue Fist", open: true, rating: 2, created_at: Time.now + 1)
+    dojo_2 = Dojo.create!(name: "Fist of Truth", open: false, rating: 4, created_at: Time.now + 1.5)
+    dojo_3 = Dojo.create!(name: "Fists of Fury", open: true, rating: 1, created_at: Time.now + 2)
+
+    dojos = [dojo, dojo_2, dojo_3]
+    expect(Dojo.recently_created).to eq(dojos)
+  end
 end


### PR DESCRIPTION
PR Includes:
- Dojo/Instructor sort only.
- Company/Seed and Dojo/Instructor Count on each show page.