### PR TITLE
Parent index sort

### DIFF
--- a/app/controllers/company_seeds_controller.rb
+++ b/app/controllers/company_seeds_controller.rb
@@ -2,6 +2,5 @@ class CompanySeedsController < ApplicationController
   def index
     company = Company.find(params[:id])
     @seeds = company.seeds
-    require 'pry'; binding.pry
   end
 end

--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -1,6 +1,6 @@
 class DojosController < ApplicationController
   def index
-    @dojos = Dojo.all.order(:created_at)
+    @dojos = Dojo.all
   end
 
   def show

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,3 +1,7 @@
 class Company < ApplicationRecord
   has_many :seeds
+
+  def self.recently_created
+    order(:created_at)
+  end
 end

--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -1,3 +1,4 @@
-<% @companies.each do |company| %>
+<% @companies.recently_created.each do |company| %>
   <p><%= company.name %></p>
+  <p><%= company.created_at %></p>
 <% end %>

--- a/app/views/dojos/index.html.erb
+++ b/app/views/dojos/index.html.erb
@@ -1,4 +1,4 @@
-<% @dojos.each do |dojo| %>
+<% @dojos.recently_created.each do |dojo| %>
   <p><%= dojo.name %></p>
   <p><%= dojo.created_at %></p>
 <% end %>

--- a/spec/features/companies/index_spec.rb
+++ b/spec/features/companies/index_spec.rb
@@ -8,6 +8,17 @@ RSpec.describe 'company index page' do
 
       expect(page).to have_content(company.name)
     end
+
+    it 'returns the name of each company in order of most recently created' do
+      company = Company.create!(name: "Johnny's Seeds", accepting_orders: true, years_active: 10)
+      company_2 = Company.create!(name: "Turing Seeds", accepting_orders: false, years_active: 12)
+      company_3 = Company.create!(name: "Seeds of Fury", accepting_orders: true, years_active: 1)
+
+      visit "/companies"
+
+      expect(company.name).to appear_before(company_2.name)
+      expect(company_2.name).to appear_before(company_3.name)
+    end
   end
 end
 

--- a/spec/features/dojos/index_spec.rb
+++ b/spec/features/dojos/index_spec.rb
@@ -4,15 +4,16 @@ RSpec.describe 'dojo index page' do
   describe 'when I navigate to /dojos' do
     it 'returns the name of each dojo' do
       dojo = Dojo.create!(name: "Blue Fist", open: true, rating: 2)
+
       visit "/dojos"
 
       expect(page).to have_content(dojo.name)
     end
 
     it 'returns the name of each dojo in order of most recently created' do
-      dojo = Dojo.create!(name: "Blue Fist", open: true, rating: 2, created_at: Time.now + 1)
-      dojo_2 = Dojo.create!(name: "Fist of Truth", open: false, rating: 4, created_at: Time.now + 2)
-      dojo_3 = Dojo.create!(name: "Fists of Fury", open: true, rating: 1, created_at: Time.now + 3)
+      dojo = Dojo.create!(name: "Blue Fist", open: true, rating: 2)
+      dojo_2 = Dojo.create!(name: "Fist of Truth", open: false, rating: 4)
+      dojo_3 = Dojo.create!(name: "Fists of Fury", open: true, rating: 1)
 
       visit "/dojos"
 

--- a/spec/features/dojos/instructors/index_spec.rb
+++ b/spec/features/dojos/instructors/index_spec.rb
@@ -9,13 +9,11 @@ RSpec.describe 'dojos instructor index' do
     instructor_2 = dojo_2.instructors.create!(name: "Jimmy", payroll: false, experience: 55)
 
     visit "/dojos/#{dojo.id}/instructors"
-    save_and_open_page
+
     expect(page).to have_content(instructor.name)
     expect(page).to have_content(instructor.payroll)
     expect(page).to have_content(instructor.experience)
 
     expect(page).to_not have_content(instructor_2.name)
-    expect(page).to_not have_content(instructor_2.payroll)
-    expect(page).to_not have_content(instructor_2.experience)
   end
 end

--- a/spec/features/seeds/show_spec.rb
+++ b/spec/features/seeds/show_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe 'seed show page' do
       expect(page).to have_content(seed.quantity)
 
       expect(page).to_not have_content(seed_2.name)
-      expect(page).to_not have_content(seed_2.available)
-      expect(page).to_not have_content(seed_2.quantity)
     end
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -2,4 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Company do
   it { should have_many :seeds }
+
+  it 'returns the name of each company in order of most recently created' do
+    company = Company.create!(name: "Johnny's Seeds", accepting_orders: true, years_active: 10)
+    company_2 = Company.create!(name: "Turing Seeds", accepting_orders: false, years_active: 12)
+    company_3 = Company.create!(name: "Seeds of Fury", accepting_orders: true, years_active: 1)
+
+    companies = [company, company_2, company_3]
+    expect(Company.recently_created).to eq(companies)
+  end
 end

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Dojo do
   it { should have_many :instructors }
 
   it 'order the dojos by most recently created' do
-    dojo = Dojo.create!(name: "Blue Fist", open: true, rating: 2, created_at: Time.now + 1)
-    dojo_2 = Dojo.create!(name: "Fist of Truth", open: false, rating: 4, created_at: Time.now + 1.5)
-    dojo_3 = Dojo.create!(name: "Fists of Fury", open: true, rating: 1, created_at: Time.now + 2)
+    dojo = Dojo.create!(name: "Blue Fist", open: true, rating: 2)
+    dojo_2 = Dojo.create!(name: "Fist of Truth", open: false, rating: 4)
+    dojo_3 = Dojo.create!(name: "Fists of Fury", open: true, rating: 1)
 
     dojos = [dojo, dojo_2, dojo_3]
     expect(Dojo.recently_created).to eq(dojos)


### PR DESCRIPTION
PR Includes:
-Fix sort for Dojo/Instructors.
-Create sort for Company/Seeds
-Create Dojo/Instructors and Company/Seeds count.